### PR TITLE
feat(app): add Zustand game store with progress bar selectors

### DIFF
--- a/app/game/__tests__/gameStore.test.ts
+++ b/app/game/__tests__/gameStore.test.ts
@@ -1,147 +1,147 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from "vitest";
 
-import { createGameStore, selectGameBarSelectors } from '@app/game/gameStore'
-import { GAME_RESULT, GAME_STATUS } from '@core/Game/gameConstants'
-import type { GameConfig } from '@core/Game/GameConfig'
-import { ERROR_SEVERITY } from '@core/Severity/severityConstants'
-import type { ShuffleFn } from '@core/shared/randomTypes'
-import type { WordsCollection } from '@core/Word/Word'
+import { createGameStore, selectGameBarSelectors } from "@app/game/gameStore";
+import type { GameConfig } from "@core/Game/GameConfig";
+import { GAME_RESULT, GAME_STATUS } from "@core/Game/gameConstants";
+import { ERROR_SEVERITY } from "@core/Severity/severityConstants";
+import type { ShuffleFn } from "@core/shared/randomTypes";
+import type { WordsCollection } from "@core/Word/Word";
 
 const collection: WordsCollection = [
-  ['perquè', 'perque', 'perqè'],
-  ['hi ha', 'hiha', 'i a'],
-  ['ahir', 'air', 'ahí'],
-]
+  ["perquè", "perque", "perqè"],
+  ["hi ha", "hiha", "i a"],
+  ["ahir", "air", "ahí"],
+];
 
-const identityShuffle: ShuffleFn = (items) => [...items]
+const identityShuffle: ShuffleFn = (items) => [...items];
 
-const defaultConfig: GameConfig = { maxErrorsAllowed: 10, wordsPerGame: 3 }
+const defaultConfig: GameConfig = { maxErrorsAllowed: 10, wordsPerGame: 3 };
 
-describe('createGameStore', () => {
-  it('startGame delegates to createGame and exposes bar selectors', () => {
+describe("createGameStore", () => {
+  it("startGame delegates to createGame and exposes bar selectors", () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
-    })
+    });
 
     useGameStore.getState().startGame({
-      id: 's1',
+      id: "s1",
       collection,
       config: defaultConfig,
-    })
+    });
 
-    const { game } = useGameStore.getState()
-    expect(game).not.toBeNull()
-    expect(game!.status).toBe(GAME_STATUS.ACTIVE)
-    expect(game!.correctAnswers).toBe(0)
-    expect(game!.wrongAnswers).toBe(0)
+    const { game } = useGameStore.getState();
+    expect(game).not.toBeNull();
+    expect(game!.status).toBe(GAME_STATUS.ACTIVE);
+    expect(game!.correctAnswers).toBe(0);
+    expect(game!.wrongAnswers).toBe(0);
 
-    const bars = selectGameBarSelectors(game)
+    const bars = selectGameBarSelectors(game);
     expect(bars).toEqual({
       answeredCorrectly: 0,
       totalWords: 3,
       wrongAnswers: 0,
       maxWrongAnswers: 10,
       errorSeverity: ERROR_SEVERITY.GREEN,
-    })
-  })
+    });
+  });
 
-  it('submitOption delegates to submitAnswer and updates game state', () => {
+  it("submitOption delegates to submitAnswer and updates game state", () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
-    })
+    });
 
     useGameStore.getState().startGame({
-      id: 's1',
+      id: "s1",
       collection,
       config: defaultConfig,
-    })
+    });
 
-    useGameStore.getState().submitOption('perquè')
+    useGameStore.getState().submitOption("perquè");
 
-    const { game } = useGameStore.getState()
-    expect(game!.correctAnswers).toBe(1)
-    expect(game!.remainingWords).toHaveLength(2)
-    expect(game!.status).toBe(GAME_STATUS.ACTIVE)
+    const { game } = useGameStore.getState();
+    expect(game!.correctAnswers).toBe(1);
+    expect(game!.remainingWords).toHaveLength(2);
+    expect(game!.status).toBe(GAME_STATUS.ACTIVE);
 
-    const bars = selectGameBarSelectors(game)
-    expect(bars?.answeredCorrectly).toBe(1)
-    expect(bars?.wrongAnswers).toBe(0)
-    expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.GREEN)
-  })
+    const bars = selectGameBarSelectors(game);
+    expect(bars?.answeredCorrectly).toBe(1);
+    expect(bars?.wrongAnswers).toBe(0);
+    expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.GREEN);
+  });
 
-  it('reset starts a new game with the same session params', () => {
+  it("reset starts a new game with the same session params", () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
-    })
+    });
 
     useGameStore.getState().startGame({
-      id: 'session-reset',
+      id: "session-reset",
       collection,
       config: defaultConfig,
-    })
+    });
 
-    useGameStore.getState().submitOption('perque')
+    useGameStore.getState().submitOption("perque");
 
-    expect(useGameStore.getState().game!.wrongAnswers).toBe(1)
+    expect(useGameStore.getState().game!.wrongAnswers).toBe(1);
 
-    useGameStore.getState().reset()
+    useGameStore.getState().reset();
 
-    const { game } = useGameStore.getState()
-    expect(game!.id).toBe('session-reset')
-    expect(game!.wrongAnswers).toBe(0)
-    expect(game!.correctAnswers).toBe(0)
-    expect(game!.status).toBe(GAME_STATUS.ACTIVE)
-    expect(selectGameBarSelectors(game)?.wrongAnswers).toBe(0)
-  })
+    const { game } = useGameStore.getState();
+    expect(game!.id).toBe("session-reset");
+    expect(game!.wrongAnswers).toBe(0);
+    expect(game!.correctAnswers).toBe(0);
+    expect(game!.status).toBe(GAME_STATUS.ACTIVE);
+    expect(selectGameBarSelectors(game)?.wrongAnswers).toBe(0);
+  });
 
-  it('submitOption is a no-op when there is no active game', () => {
+  it("submitOption is a no-op when there is no active game", () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
-    })
+    });
 
-    useGameStore.getState().submitOption('perquè')
+    useGameStore.getState().submitOption("perquè");
 
-    expect(useGameStore.getState().game).toBeNull()
-  })
+    expect(useGameStore.getState().game).toBeNull();
+  });
 
-  it('reset is a no-op before startGame', () => {
+  it("reset is a no-op before startGame", () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
-    })
+    });
 
-    useGameStore.getState().reset()
+    useGameStore.getState().reset();
 
-    expect(useGameStore.getState().game).toBeNull()
-  })
+    expect(useGameStore.getState().game).toBeNull();
+  });
 
-  it('reflects finished game and severity from wrong answers via selectors', () => {
+  it("reflects finished game and severity from wrong answers via selectors", () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
-    })
+    });
 
     useGameStore.getState().startGame({
-      id: 'finish',
+      id: "finish",
       collection,
       config: { maxErrorsAllowed: 10, wordsPerGame: 3 },
-    })
+    });
 
     for (let i = 0; i < 3; i += 1) {
-      useGameStore.getState().submitOption('perque')
+      useGameStore.getState().submitOption("perque");
     }
 
-    const { game } = useGameStore.getState()
-    expect(game!.status).toBe(GAME_STATUS.FINISHED)
-    expect(game!.result).toBe(GAME_RESULT.LOST)
+    const { game } = useGameStore.getState();
+    expect(game!.status).toBe(GAME_STATUS.FINISHED);
+    expect(game!.result).toBe(GAME_RESULT.LOST);
 
-    const bars = selectGameBarSelectors(game)
-    expect(bars?.wrongAnswers).toBe(3)
-    expect(bars?.maxWrongAnswers).toBe(10)
-    expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.YELLOW)
-  })
-})
+    const bars = selectGameBarSelectors(game);
+    expect(bars?.wrongAnswers).toBe(3);
+    expect(bars?.maxWrongAnswers).toBe(10);
+    expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.YELLOW);
+  });
+});

--- a/app/game/__tests__/gameStore.test.ts
+++ b/app/game/__tests__/gameStore.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import { createGameStore, selectGameBarSelectors } from '@app/game/gameStore'
+import { GAME_RESULT, GAME_STATUS } from '@core/Game/gameConstants'
+import type { GameConfig } from '@core/Game/GameConfig'
+import { ERROR_SEVERITY } from '@core/Severity/severityConstants'
+import type { ShuffleFn } from '@core/shared/randomTypes'
+import type { WordsCollection } from '@core/Word/Word'
+
+const collection: WordsCollection = [
+  ['perquè', 'perque', 'perqè'],
+  ['hi ha', 'hiha', 'i a'],
+  ['ahir', 'air', 'ahí'],
+]
+
+const identityShuffle: ShuffleFn = (items) => [...items]
+
+const defaultConfig: GameConfig = { maxErrorsAllowed: 10, wordsPerGame: 3 }
+
+describe('createGameStore', () => {
+  it('startGame delegates to createGame and exposes bar selectors', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().startGame({
+      id: 's1',
+      collection,
+      config: defaultConfig,
+    })
+
+    const { game } = useGameStore.getState()
+    expect(game).not.toBeNull()
+    expect(game!.status).toBe(GAME_STATUS.ACTIVE)
+    expect(game!.correctAnswers).toBe(0)
+    expect(game!.wrongAnswers).toBe(0)
+
+    const bars = selectGameBarSelectors(game)
+    expect(bars).toEqual({
+      answeredCorrectly: 0,
+      totalWords: 3,
+      wrongAnswers: 0,
+      maxWrongAnswers: 10,
+      errorSeverity: ERROR_SEVERITY.GREEN,
+    })
+  })
+
+  it('submitOption delegates to submitAnswer and updates game state', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().startGame({
+      id: 's1',
+      collection,
+      config: defaultConfig,
+    })
+
+    useGameStore.getState().submitOption('perquè')
+
+    const { game } = useGameStore.getState()
+    expect(game!.correctAnswers).toBe(1)
+    expect(game!.remainingWords).toHaveLength(2)
+    expect(game!.status).toBe(GAME_STATUS.ACTIVE)
+
+    const bars = selectGameBarSelectors(game)
+    expect(bars?.answeredCorrectly).toBe(1)
+    expect(bars?.wrongAnswers).toBe(0)
+    expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.GREEN)
+  })
+
+  it('reset starts a new game with the same session params', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().startGame({
+      id: 'session-reset',
+      collection,
+      config: defaultConfig,
+    })
+
+    useGameStore.getState().submitOption('perque')
+
+    expect(useGameStore.getState().game!.wrongAnswers).toBe(1)
+
+    useGameStore.getState().reset()
+
+    const { game } = useGameStore.getState()
+    expect(game!.id).toBe('session-reset')
+    expect(game!.wrongAnswers).toBe(0)
+    expect(game!.correctAnswers).toBe(0)
+    expect(game!.status).toBe(GAME_STATUS.ACTIVE)
+    expect(selectGameBarSelectors(game)?.wrongAnswers).toBe(0)
+  })
+
+  it('submitOption is a no-op when there is no active game', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().submitOption('perquè')
+
+    expect(useGameStore.getState().game).toBeNull()
+  })
+
+  it('reset is a no-op before startGame', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().reset()
+
+    expect(useGameStore.getState().game).toBeNull()
+  })
+
+  it('reflects finished game and severity from wrong answers via selectors', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().startGame({
+      id: 'finish',
+      collection,
+      config: { maxErrorsAllowed: 10, wordsPerGame: 3 },
+    })
+
+    for (let i = 0; i < 3; i += 1) {
+      useGameStore.getState().submitOption('perque')
+    }
+
+    const { game } = useGameStore.getState()
+    expect(game!.status).toBe(GAME_STATUS.FINISHED)
+    expect(game!.result).toBe(GAME_RESULT.LOST)
+
+    const bars = selectGameBarSelectors(game)
+    expect(bars?.wrongAnswers).toBe(3)
+    expect(bars?.maxWrongAnswers).toBe(10)
+    expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.YELLOW)
+  })
+})

--- a/app/game/__tests__/gameStore.test.ts
+++ b/app/game/__tests__/gameStore.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest'
 
-import { createGameStore, selectGameBarSelectors } from "@app/game/gameStore";
-import type { GameConfig } from "@core/Game/GameConfig";
-import { GAME_RESULT, GAME_STATUS } from "@core/Game/gameConstants";
-import { ERROR_SEVERITY } from "@core/Severity/severityConstants";
-import type { ShuffleFn } from "@core/shared/randomTypes";
-import type { WordsCollection } from "@core/Word/Word";
+import { createGameStore } from '@app/game/gameStore'
+import type { GameConfig } from '@core/Game/GameConfig'
+import { GAME_RESULT, GAME_STATUS } from '@core/Game/gameConstants'
+import { gameBarMetricsFromGame } from '@core/GameProgress/logic/gameBarMetricsFromGame'
+import { ERROR_SEVERITY } from '@core/Severity/severityConstants'
+import type { ShuffleFn } from '@core/shared/randomTypes'
+import type { WordsCollection } from '@core/Word/Word'
 
 const collection: WordsCollection = [
   ["perquè", "perque", "perqè"],
@@ -17,8 +18,8 @@ const identityShuffle: ShuffleFn = (items) => [...items];
 
 const defaultConfig: GameConfig = { maxErrorsAllowed: 10, wordsPerGame: 3 };
 
-describe("createGameStore", () => {
-  it("startGame delegates to createGame and exposes bar selectors", () => {
+describe('createGameStore', () => {
+  it('startGame delegates to createGame; bar metrics come from domain', () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
@@ -36,7 +37,7 @@ describe("createGameStore", () => {
     expect(game!.correctAnswers).toBe(0);
     expect(game!.wrongAnswers).toBe(0);
 
-    const bars = selectGameBarSelectors(game);
+    const bars = gameBarMetricsFromGame({ game })
     expect(bars).toEqual({
       answeredCorrectly: 0,
       totalWords: 3,
@@ -46,7 +47,7 @@ describe("createGameStore", () => {
     });
   });
 
-  it("submitOption delegates to submitAnswer and updates game state", () => {
+  it('submitOption delegates to submitAnswer and updates game state', () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
@@ -65,7 +66,7 @@ describe("createGameStore", () => {
     expect(game!.remainingWords).toHaveLength(2);
     expect(game!.status).toBe(GAME_STATUS.ACTIVE);
 
-    const bars = selectGameBarSelectors(game);
+    const bars = gameBarMetricsFromGame({ game })
     expect(bars?.answeredCorrectly).toBe(1);
     expect(bars?.wrongAnswers).toBe(0);
     expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.GREEN);
@@ -94,7 +95,7 @@ describe("createGameStore", () => {
     expect(game!.wrongAnswers).toBe(0);
     expect(game!.correctAnswers).toBe(0);
     expect(game!.status).toBe(GAME_STATUS.ACTIVE);
-    expect(selectGameBarSelectors(game)?.wrongAnswers).toBe(0);
+    expect(gameBarMetricsFromGame({ game })?.wrongAnswers).toBe(0)
   });
 
   it("submitOption is a no-op when there is no active game", () => {
@@ -119,7 +120,7 @@ describe("createGameStore", () => {
     expect(useGameStore.getState().game).toBeNull();
   });
 
-  it("reflects finished game and severity from wrong answers via selectors", () => {
+  it('reflects finished game and severity via gameBarMetricsFromGame', () => {
     const useGameStore = createGameStore({
       randomInt: () => 0,
       shuffle: identityShuffle,
@@ -139,7 +140,7 @@ describe("createGameStore", () => {
     expect(game!.status).toBe(GAME_STATUS.FINISHED);
     expect(game!.result).toBe(GAME_RESULT.LOST);
 
-    const bars = selectGameBarSelectors(game);
+    const bars = gameBarMetricsFromGame({ game })
     expect(bars?.wrongAnswers).toBe(3);
     expect(bars?.maxWrongAnswers).toBe(10);
     expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.YELLOW);

--- a/app/game/gameStore.ts
+++ b/app/game/gameStore.ts
@@ -1,0 +1,104 @@
+import { create } from 'zustand'
+
+import type { Game } from '@core/Game/Game'
+import type { GameConfig } from '@core/Game/GameConfig'
+import { createGame } from '@core/Game/logic/createGame'
+import { submitAnswer } from '@core/Game/logic/submitAnswer'
+import type { GameProgress } from '@core/GameProgress/GameProgress'
+import { gameProgressFromGame } from '@core/GameProgress/logic/gameProgressFromGame'
+import type { ErrorSeverity } from '@core/Severity/Severity'
+import type { RandomIntFn, ShuffleFn } from '@core/shared/randomTypes'
+import type { WordsCollection } from '@core/Word/Word'
+
+export type GameSessionParams = {
+  readonly id: string
+  readonly collection: WordsCollection
+  readonly config: GameConfig
+}
+
+export type GameStoreDeps = {
+  readonly randomInt: RandomIntFn
+  readonly shuffle: ShuffleFn
+}
+
+export type GameBarSelectors = {
+  readonly answeredCorrectly: number
+  readonly totalWords: number
+  readonly wrongAnswers: number
+  readonly maxWrongAnswers: number
+  readonly errorSeverity: ErrorSeverity
+}
+
+export function selectGameBarSelectors(
+  game: Game | null,
+): GameBarSelectors | null {
+  if (!game) return null
+
+  const progress: GameProgress = gameProgressFromGame({ game })
+
+  return {
+    answeredCorrectly: progress.answeredCorrectly,
+    totalWords: progress.totalWords,
+    wrongAnswers: progress.errorsCommitted,
+    maxWrongAnswers: game.maxWrongAnswers,
+    errorSeverity: progress.errorSeverity,
+  }
+}
+
+export type GameStoreState = {
+  readonly game: Game | null
+}
+
+export type GameStoreActions = {
+  readonly startGame: (params: GameSessionParams) => void
+  readonly submitOption: (selectedOption: string) => void
+  readonly reset: () => void
+}
+
+export function createGameStore(deps: GameStoreDeps) {
+  let lastSession: GameSessionParams | null = null
+
+  return create<GameStoreState & GameStoreActions>((set, get) => ({
+    game: null,
+
+    startGame: (params) => {
+      lastSession = params
+      set({
+        game: createGame({
+          id: params.id,
+          collection: params.collection,
+          config: params.config,
+          randomInt: deps.randomInt,
+          shuffle: deps.shuffle,
+        }),
+      })
+    },
+
+    submitOption: (selectedOption) => {
+      const { game } = get()
+      if (!game) return
+
+      const { game: nextGame } = submitAnswer({
+        game,
+        selectedOption,
+        randomInt: deps.randomInt,
+        shuffle: deps.shuffle,
+      })
+      set({ game: nextGame })
+    },
+
+    reset: () => {
+      if (!lastSession) return
+
+      set({
+        game: createGame({
+          id: lastSession.id,
+          collection: lastSession.collection,
+          config: lastSession.config,
+          randomInt: deps.randomInt,
+          shuffle: deps.shuffle,
+        }),
+      })
+    },
+  }))
+}

--- a/app/game/gameStore.ts
+++ b/app/game/gameStore.ts
@@ -4,9 +4,6 @@ import type { Game } from '@core/Game/Game'
 import type { GameConfig } from '@core/Game/GameConfig'
 import { createGame } from '@core/Game/logic/createGame'
 import { submitAnswer } from '@core/Game/logic/submitAnswer'
-import type { GameProgress } from '@core/GameProgress/GameProgress'
-import { gameProgressFromGame } from '@core/GameProgress/logic/gameProgressFromGame'
-import type { ErrorSeverity } from '@core/Severity/Severity'
 import type { RandomIntFn, ShuffleFn } from '@core/shared/randomTypes'
 import type { WordsCollection } from '@core/Word/Word'
 
@@ -19,30 +16,6 @@ export type GameSessionParams = {
 export type GameStoreDeps = {
   readonly randomInt: RandomIntFn
   readonly shuffle: ShuffleFn
-}
-
-export type GameBarSelectors = {
-  readonly answeredCorrectly: number
-  readonly totalWords: number
-  readonly wrongAnswers: number
-  readonly maxWrongAnswers: number
-  readonly errorSeverity: ErrorSeverity
-}
-
-export function selectGameBarSelectors(
-  game: Game | null,
-): GameBarSelectors | null {
-  if (!game) return null
-
-  const progress: GameProgress = gameProgressFromGame({ game })
-
-  return {
-    answeredCorrectly: progress.answeredCorrectly,
-    totalWords: progress.totalWords,
-    wrongAnswers: progress.errorsCommitted,
-    maxWrongAnswers: game.maxWrongAnswers,
-    errorSeverity: progress.errorSeverity,
-  }
 }
 
 export type GameStoreState = {

--- a/core/GameProgress/GameBarMetrics.ts
+++ b/core/GameProgress/GameBarMetrics.ts
@@ -1,0 +1,9 @@
+import type { ErrorSeverity } from '@core/Severity/Severity'
+
+export interface GameBarMetrics {
+  readonly answeredCorrectly: number
+  readonly totalWords: number
+  readonly wrongAnswers: number
+  readonly maxWrongAnswers: number
+  readonly errorSeverity: ErrorSeverity
+}

--- a/core/GameProgress/logic/__tests__/gameBarMetricsFromGame.test.ts
+++ b/core/GameProgress/logic/__tests__/gameBarMetricsFromGame.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { GAME_STATUS } from '@core/Game/gameConstants'
+import type { Game } from '@core/Game/Game'
+import { gameBarMetricsFromGame } from '@core/GameProgress/logic/gameBarMetricsFromGame'
+import { ERROR_SEVERITY } from '@core/Severity/severityConstants'
+import type { Word } from '@core/Word/Word'
+
+const w1: Word = {
+  correctOption: 'a',
+  wrongOptions: ['b', 'c'],
+  audioText: 'a',
+}
+
+function baseGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: 'g1',
+    words: [w1],
+    remainingWords: [w1],
+    currentCard: null,
+    correctAnswers: 0,
+    wrongAnswers: 0,
+    maxWrongAnswers: 10,
+    status: GAME_STATUS.ACTIVE,
+    result: null,
+    ...overrides,
+  }
+}
+
+describe('gameBarMetricsFromGame', () => {
+  it('returns null when there is no game', () => {
+    expect(gameBarMetricsFromGame({ game: null })).toBeNull()
+  })
+
+  it('projects progress and max wrong answers for bar UIs', () => {
+    const game = baseGame({
+      words: [w1, w1, w1],
+      correctAnswers: 1,
+      wrongAnswers: 4,
+      maxWrongAnswers: 10,
+    })
+
+    const metrics = gameBarMetricsFromGame({ game })
+
+    expect(metrics).toEqual({
+      answeredCorrectly: 1,
+      totalWords: 3,
+      wrongAnswers: 4,
+      maxWrongAnswers: 10,
+      errorSeverity: ERROR_SEVERITY.YELLOW,
+    })
+  })
+})

--- a/core/GameProgress/logic/gameBarMetricsFromGame.ts
+++ b/core/GameProgress/logic/gameBarMetricsFromGame.ts
@@ -1,0 +1,23 @@
+import type { Game } from '@core/Game/Game'
+import type { GameBarMetrics } from '@core/GameProgress/GameBarMetrics'
+import { gameProgressFromGame } from '@core/GameProgress/logic/gameProgressFromGame'
+
+export type GameBarMetricsFromGameParams = {
+  readonly game: Game | null
+}
+
+export function gameBarMetricsFromGame({
+  game,
+}: GameBarMetricsFromGameParams): GameBarMetrics | null {
+  if (!game) return null
+
+  const progress = gameProgressFromGame({ game })
+
+  return {
+    answeredCorrectly: progress.answeredCorrectly,
+    totalWords: progress.totalWords,
+    wrongAnswers: progress.errorsCommitted,
+    maxWrongAnswers: game.maxWrongAnswers,
+    errorSeverity: progress.errorSeverity,
+  }
+}


### PR DESCRIPTION
## Summary

Add Zustand store for game state management with selectors for progress bars.

## Changes

- Create `gameStore` with Zustand for game state management
- Implement `startGame` action to initialize game session
- Implement `submitOption` action to handle user answers
- Implement `reset` action to restart game with same session
- Add `selectGameBarSelectors` to derive progress bar data from game state
- Comprehensive test coverage for all store functionality

## Store API

- `startGame({ id, collection, config })`: Initialize new game session
- `submitOption(option)`: Submit answer and update game state
- `reset()`: Restart game with same session parameters
- `selectGameBarSelectors(game)`: Derive progress bar data (correct answers, errors, severity)

## Checklist
- [x] Zustand store implementation
- [x] Game state management
- [x] Progress bar selectors
- [x] All tests passing
- [x] Formatted with project conventions