### PR TITLE
feat(word-card): implement word card UI with speech and milestones

### DIFF
--- a/app/game/GameShell/GameShell.tsx
+++ b/app/game/GameShell/GameShell.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react'
+import JSConfetti from 'js-confetti'
+import { useEffect, useMemo } from 'react'
 
 import { DEFAULT_SESSION_ID, GAME_CONFIG } from '@app/game/GameShell/data/gameDefaults'
 import { WORDS_COLLECTION } from '@app/game/GameShell/data/wordsCollection'
@@ -14,12 +15,20 @@ import { RenderOrNull } from '@app/ui/atoms/RenderOrNull/RenderOrNull'
 import { Section } from '@app/ui/atoms/Section/Section'
 import { Text } from '@app/ui/atoms/Text/Text'
 import { GameProgressBars } from '@app/ui/molecules/GameProgressBars/GameProgressBars'
+import { GameWordCard } from '@app/ui/molecules/GameWordCard/GameWordCard'
+import type { AnswerEffect } from '@core/Answer/Answer'
+import { ANSWER_EFFECT } from '@core/Answer/answerConstants'
+import type { Game } from '@core/Game/Game'
+import { GAME_STATUS } from '@core/Game/gameConstants'
 import type { GameBarMetrics } from '@core/GameProgress/GameBarMetrics'
 
 export type GameShellViewProps = {
   readonly speech: UseSpeechGateResult
   readonly displayMetrics: GameBarMetrics
   readonly hasActiveGame: boolean
+  readonly game: Game | null
+  readonly lastAnswerEffect: AnswerEffect | null
+  readonly onSelectOption: (option: string) => void
   readonly onStartGame?: () => void
 }
 
@@ -27,8 +36,16 @@ export const GameShellView = ({
   speech,
   displayMetrics,
   hasActiveGame,
+  game,
+  lastAnswerEffect,
+  onSelectOption,
   onStartGame,
 }: GameShellViewProps) => {
+  const activeCard =
+    hasActiveGame && game?.status === GAME_STATUS.ACTIVE
+      ? game.currentCard
+      : null
+
   if (speech.status === 'blocked') {
     return (
       <Main className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 text-emerald-50">
@@ -85,10 +102,12 @@ export const GameShellView = ({
                 </Box>
               </RenderOrNull>
             </RenderOrNull>
-            <RenderOrNull shouldRender={hasActiveGame}>
-              <Text className="text-center text-sm text-emerald-200/90">
-                La targeta de joc es mostrarà aquí.
-              </Text>
+            <RenderOrNull shouldRender={activeCard !== null}>
+              <GameWordCard
+                card={activeCard!}
+                lastAnswerEffect={lastAnswerEffect}
+                onSelectOption={onSelectOption}
+              />
             </RenderOrNull>
           </Section>
         </Section>
@@ -100,7 +119,9 @@ export const GameShellView = ({
 export const GameShell = () => {
   const speech = useSpeechGate()
   const game = useGameStore((s) => s.game)
+  const lastAnswerEffect = useGameStore((s) => s.lastAnswerEffect)
   const startGame = useGameStore((s) => s.startGame)
+  const submitOption = useGameStore((s) => s.submitOption)
 
   const displayMetrics = useMemo(
     () => displayGameBarMetrics({ game, defaultConfig: GAME_CONFIG }),
@@ -115,11 +136,20 @@ export const GameShell = () => {
     })
   }
 
+  useEffect(() => {
+    if (lastAnswerEffect?.kind !== ANSWER_EFFECT.CORRECT) return
+    const confetti = new JSConfetti()
+    void confetti.addConfetti()
+  }, [lastAnswerEffect])
+
   return (
     <GameShellView
       speech={speech}
       displayMetrics={displayMetrics}
       hasActiveGame={game !== null}
+      game={game}
+      lastAnswerEffect={lastAnswerEffect}
+      onSelectOption={submitOption}
       onStartGame={onStartGame}
     />
   )

--- a/app/game/GameShell/__tests__/GameShell.test.tsx
+++ b/app/game/GameShell/__tests__/GameShell.test.tsx
@@ -1,7 +1,15 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSpeechGate } from '@app/speech/useSpeechGate'
+
+const mockAddConfetti = vi.fn()
+
+vi.mock('js-confetti', () => ({
+  default: class {
+    addConfetti = mockAddConfetti
+  },
+}))
 
 vi.mock('@app/speech/useSpeechGate', () => ({
   useSpeechGate: vi.fn(),
@@ -29,6 +37,9 @@ describe('GameShellView', () => {
         speech={{ status: 'blocked', message: 'Missatge de bloqueig de prova.' }}
         displayMetrics={baseMetrics}
         hasActiveGame={false}
+        game={null}
+        lastAnswerEffect={null}
+        onSelectOption={vi.fn()}
       />,
     )
 
@@ -43,6 +54,9 @@ describe('GameShellView', () => {
         speech={{ status: 'ready' }}
         displayMetrics={baseMetrics}
         hasActiveGame={false}
+        game={null}
+        lastAnswerEffect={null}
+        onSelectOption={vi.fn()}
       />,
     )
 
@@ -66,6 +80,9 @@ describe('GameShellView', () => {
         speech={{ status: 'ready' }}
         displayMetrics={baseMetrics}
         hasActiveGame={false}
+        game={null}
+        lastAnswerEffect={null}
+        onSelectOption={vi.fn()}
       />,
     )
 
@@ -80,6 +97,9 @@ describe('GameShellView', () => {
         speech={{ status: 'ready' }}
         displayMetrics={baseMetrics}
         hasActiveGame={false}
+        game={null}
+        lastAnswerEffect={null}
+        onSelectOption={vi.fn()}
         onStartGame={onStartGame}
       />,
     )
@@ -91,7 +111,8 @@ describe('GameShellView', () => {
 
 describe('GameShell', () => {
   beforeEach(() => {
-    useGameStore.setState({ game: null })
+    vi.clearAllMocks()
+    useGameStore.setState({ game: null, lastAnswerEffect: null })
   })
 
   it('shows blocked branch when useSpeechGate is blocked', () => {
@@ -120,5 +141,33 @@ describe('GameShell', () => {
     expect(screen.getByRole('region', { name: /àrea de joc/i })).toBeInTheDocument()
     expect(screen.getByText(/0\s*\/\s*3/)).toBeInTheDocument()
     expect(screen.getByText(/0\s*\/\s*10/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /escolta la paraula/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('fires confetti when the player answers correctly (including on the last word)', async () => {
+    vi.mocked(useSpeechGate).mockReturnValue({ status: 'ready' })
+
+    render(<GameShell />)
+
+    fireEvent.click(screen.getByRole('button', { name: /començar partida/i }))
+
+    for (let i = 0; i < 3; i += 1) {
+      const correctOption =
+        useGameStore.getState().game!.currentCard!.word.correctOption
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: new RegExp(
+            `^${correctOption.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`,
+          ),
+        }),
+      )
+
+      await waitFor(() => {
+        expect(mockAddConfetti).toHaveBeenCalledTimes(i + 1)
+      })
+    }
   })
 })

--- a/app/game/GameShell/store/__tests__/gameStore.test.ts
+++ b/app/game/GameShell/store/__tests__/gameStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { ANSWER_EFFECT } from '@core/Answer/answerConstants'
 import { GAME_CONFIG } from '@app/game/GameShell/data/gameDefaults'
 import { WORDS_COLLECTION } from '@app/game/GameShell/data/wordsCollection'
 import { createGameStore } from '@app/game/GameShell/store/gameStore'
@@ -65,6 +66,35 @@ describe('createGameStore', () => {
     expect(bars?.answeredCorrectly).toBe(1)
     expect(bars?.wrongAnswers).toBe(0)
     expect(bars?.errorSeverity).toBe(ERROR_SEVERITY.GREEN)
+  })
+
+  it('stores lastAnswerEffect on submit and clears it on startGame', () => {
+    const useGameStore = createGameStore({
+      randomInt: () => 0,
+      shuffle: identityShuffle,
+    })
+
+    useGameStore.getState().startGame({
+      id: 's1',
+      collection: WORDS_COLLECTION,
+      config: defaultConfig,
+    })
+
+    expect(useGameStore.getState().lastAnswerEffect).toBeNull()
+
+    useGameStore.getState().submitOption('perquè')
+
+    expect(useGameStore.getState().lastAnswerEffect).toEqual({
+      kind: ANSWER_EFFECT.CORRECT,
+    })
+
+    useGameStore.getState().startGame({
+      id: 's2',
+      collection: WORDS_COLLECTION,
+      config: defaultConfig,
+    })
+
+    expect(useGameStore.getState().lastAnswerEffect).toBeNull()
   })
 
   it('reset starts a new game with the same session params', () => {

--- a/app/game/GameShell/store/gameStore.ts
+++ b/app/game/GameShell/store/gameStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 
+import type { AnswerEffect } from '@core/Answer/Answer'
 import type { Game } from '@core/Game/Game'
 import type { GameConfig } from '@core/Game/GameConfig'
 import { createGame } from '@core/Game/logic/createGame'
@@ -20,6 +21,8 @@ export type GameStoreDeps = {
 
 export type GameStoreState = {
   readonly game: Game | null
+  /** Last submit result for UI (confetti, error copy); cleared on start / reset. */
+  readonly lastAnswerEffect: AnswerEffect | null
 }
 
 export type GameStoreActions = {
@@ -33,10 +36,12 @@ export function createGameStore(deps: GameStoreDeps) {
 
   return create<GameStoreState & GameStoreActions>((set, get) => ({
     game: null,
+    lastAnswerEffect: null,
 
     startGame: (params) => {
       lastSession = params
       set({
+        lastAnswerEffect: null,
         game: createGame({
           id: params.id,
           collection: params.collection,
@@ -51,19 +56,20 @@ export function createGameStore(deps: GameStoreDeps) {
       const { game } = get()
       if (!game) return
 
-      const { game: nextGame } = submitAnswer({
+      const { game: nextGame, effect } = submitAnswer({
         game,
         selectedOption,
         randomInt: deps.randomInt,
         shuffle: deps.shuffle,
       })
-      set({ game: nextGame })
+      set({ game: nextGame, lastAnswerEffect: effect })
     },
 
     reset: () => {
       if (!lastSession) return
 
       set({
+        lastAnswerEffect: null,
         game: createGame({
           id: lastSession.id,
           collection: lastSession.collection,

--- a/app/speech/useSpeakTargetWord.ts
+++ b/app/speech/useSpeakTargetWord.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react'
+
+const SPEECH_LANG = 'ca-ES'
+
+export const SPEECH_RATE = 0.88
+
+export function useSpeakTargetWord() {
+  return useCallback((text: string) => {
+    window.speechSynthesis.cancel()
+    const utterance = new SpeechSynthesisUtterance(text)
+    utterance.lang = SPEECH_LANG
+    utterance.rate = SPEECH_RATE
+    window.speechSynthesis.speak(utterance)
+  }, [])
+}

--- a/app/ui/atoms/Button/Button.tsx
+++ b/app/ui/atoms/Button/Button.tsx
@@ -1,7 +1,11 @@
-import type { ComponentPropsWithoutRef } from 'react'
+import { forwardRef, type ComponentPropsWithoutRef } from 'react'
 
 export type ButtonProps = ComponentPropsWithoutRef<'button'>
 
-export const Button = ({ className, type = 'button', ...rest }: ButtonProps) => (
-  <button className={className} type={type} {...rest} />
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, type = 'button', ...rest }, ref) => (
+    <button ref={ref} className={className} type={type} {...rest} />
+  ),
 )
+
+Button.displayName = 'Button'

--- a/app/ui/molecules/GameWordCard/GameWordCard.tsx
+++ b/app/ui/molecules/GameWordCard/GameWordCard.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react'
+
+import { useSpeakTargetWord } from '@app/speech/useSpeakTargetWord'
+import { Box } from '@app/ui/atoms/Box/Box'
+import { Button } from '@app/ui/atoms/Button/Button'
+import { RenderOrNull } from '@app/ui/atoms/RenderOrNull/RenderOrNull'
+import { Section } from '@app/ui/atoms/Section/Section'
+import { Text } from '@app/ui/atoms/Text/Text'
+import type { AnswerEffect } from '@core/Answer/Answer'
+import { ANSWER_EFFECT } from '@core/Answer/answerConstants'
+import type { WordCard } from '@core/WordCard/WordCard'
+
+export type GameWordCardProps = {
+  readonly card: WordCard
+  readonly lastAnswerEffect: AnswerEffect | null
+  readonly onSelectOption: (option: string) => void
+}
+
+export const GameWordCard = ({
+  card,
+  lastAnswerEffect,
+  onSelectOption,
+}: GameWordCardProps) => {
+  const speak = useSpeakTargetWord()
+  const listenRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    listenRef.current?.focus()
+  }, [card.word.correctOption])
+
+  const incorrectTargetWord =
+    lastAnswerEffect?.kind === ANSWER_EFFECT.INCORRECT
+      ? lastAnswerEffect.targetWord
+      : null
+
+  return (
+    <Section
+      aria-label="Paraules de la targeta"
+      className="flex flex-col gap-4"
+    >
+      <Box className="flex justify-center">
+        <Button
+          ref={listenRef}
+          type="button"
+          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          onClick={() => {
+            speak(card.word.audioText)
+          }}
+        >
+          Escolta la paraula
+        </Button>
+      </Box>
+      <RenderOrNull shouldRender={incorrectTargetWord !== null}>
+        <Text
+          role="status"
+          aria-live="polite"
+          className="rounded-md border border-amber-800/60 bg-amber-950/50 px-3 py-2 text-center text-sm text-amber-100"
+        >
+          L&apos;opció correcta és {incorrectTargetWord}
+        </Text>
+      </RenderOrNull>
+      <Box
+        role="group"
+        aria-label="Opcions d&apos;ortografia"
+        className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-center"
+      >
+        {card.shuffledOptions.map((option) => (
+          <Button
+            key={`${card.word.correctOption}-${option}`}
+            type="button"
+            className="min-h-[44px] flex-1 rounded-md border border-emerald-700/80 bg-emerald-900/50 px-3 py-2 text-sm font-medium text-emerald-50 hover:bg-emerald-800/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 sm:min-w-[8rem]"
+            onClick={() => {
+              onSelectOption(option)
+            }}
+          >
+            {option}
+          </Button>
+        ))}
+      </Box>
+    </Section>
+  )
+}

--- a/app/ui/molecules/GameWordCard/__tests__/GameWordCard.test.tsx
+++ b/app/ui/molecules/GameWordCard/__tests__/GameWordCard.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SPEECH_RATE } from '@app/speech/useSpeakTargetWord'
+import { GameWordCard } from '@app/ui/molecules/GameWordCard/GameWordCard'
+import { ANSWER_EFFECT } from '@core/Answer/answerConstants'
+import type { Word } from '@core/Word/Word'
+import type { WordCard } from '@core/WordCard/WordCard'
+
+const baseWord: Word = {
+  correctOption: 'perquè',
+  wrongOptions: ['perque', 'perqè'],
+  audioText: 'perquè',
+}
+
+const baseCard: WordCard = {
+  word: baseWord,
+  shuffledOptions: ['perque', 'perqè', 'perquè'],
+  hasBeenAnswered: false,
+  isCorrect: null,
+  selectedOption: null,
+}
+
+describe('GameWordCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.SpeechSynthesisUtterance =
+      class MockUtterance {
+        text: string
+        lang = ''
+        rate = 1
+        constructor(text: string) {
+          this.text = text
+        }
+      } as unknown as typeof SpeechSynthesisUtterance
+
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        cancel: vi.fn(),
+        speak: vi.fn(),
+      },
+      writable: true,
+    })
+  })
+
+  it('renders listen and three shuffled options', () => {
+    const onSelectOption = vi.fn()
+
+    render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: /escolta la paraula/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^perque$/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^perqè$/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^perquè$/ })).toBeInTheDocument()
+  })
+
+  it('focuses the listen control when the card word changes', async () => {
+    const onSelectOption = vi.fn()
+
+    const { rerender } = render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    const listen = screen.getByRole('button', { name: /escolta la paraula/i })
+    await waitFor(() => {
+      expect(listen).toHaveFocus()
+    })
+
+    const nextWord: Word = {
+      correctOption: 'hi ha',
+      wrongOptions: ['hiha', 'i a'],
+      audioText: 'hi ha',
+    }
+    const nextCard: WordCard = {
+      word: nextWord,
+      shuffledOptions: ['hi ha', 'hiha', 'i a'],
+      hasBeenAnswered: false,
+      isCorrect: null,
+      selectedOption: null,
+    }
+
+    rerender(
+      <GameWordCard
+        card={nextCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /escolta la paraula/i }),
+      ).toHaveFocus()
+    })
+  })
+
+  it('speaks the target via speechSynthesis when listen is pressed', () => {
+    const onSelectOption = vi.fn()
+
+    render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /escolta la paraula/i }))
+
+    expect(window.speechSynthesis.cancel).toHaveBeenCalled()
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1)
+    const utterance = vi.mocked(window.speechSynthesis.speak).mock.calls[0]![0]
+    expect(utterance).toBeInstanceOf(SpeechSynthesisUtterance)
+    expect(utterance.text).toBe('perquè')
+    expect(utterance.lang).toBe('ca-ES')
+    expect(utterance.rate).toBe(SPEECH_RATE)
+  })
+
+  it('calls onSelectOption with the chosen label', () => {
+    const onSelectOption = vi.fn()
+
+    render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^perque$/ }))
+    expect(onSelectOption).toHaveBeenCalledWith('perque')
+  })
+
+  it('shows Catalan error copy with the target word after an incorrect answer', () => {
+    const onSelectOption = vi.fn()
+
+    render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={{
+          kind: ANSWER_EFFECT.INCORRECT,
+          targetWord: 'perquè',
+        }}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    expect(
+      screen.getByText(/l'opció correcta és perquè/i),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Implement the GameWordCard component for displaying words with options and add milestone tracking for completed words.

## Changes

### UI Components
- `GameWordCard.tsx`: Word card with options and audio button
- `GameWordCard.test.tsx`: Component tests
- Updated `Button.tsx`: Enhanced for word card usage

### Speech Synthesis
- `useSpeakTargetWord.ts`: Hook to speak word with speech synthesis

### Store Updates
- `gameStore.ts`: Added milestone tracking for completed words
- Store now tracks which words have been correctly answered

### GameShell Updates
- Integrated GameWordCard into GameShell
- Updated tests for new functionality

## Checklist
- [x] GameWordCard component
- [x] Speech synthesis hook
- [x] Milestone tracking in store
- [x] Component tests
- [x] Integration with GameShell