### PR TITLE
fix(a11y): contrast WCAG, SEO, robots i polish d'accessibilitat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ build/
 *.tmp
 *.temp
 .cache/
+
+# Local Netlify folder
+.netlify

--- a/app/game/GameShell/GameShell.tsx
+++ b/app/game/GameShell/GameShell.tsx
@@ -67,7 +67,10 @@ export const GameShellView = ({
 
   if (speech.status === 'blocked') {
     return (
-      <Main className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 text-emerald-50">
+      <Main
+        lang="ca"
+        className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 pb-[max(2rem,env(safe-area-inset-bottom))] text-emerald-50"
+      >
         <Section
           role="alert"
           aria-live="polite"
@@ -82,18 +85,24 @@ export const GameShellView = ({
 
   if (speech.status === 'checking') {
     return (
-      <Main className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 text-emerald-100">
+      <Main
+        lang="ca"
+        className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 pb-[max(2rem,env(safe-area-inset-bottom))] text-emerald-100"
+      >
         <Text className="text-base">S'està comprovant la veu…</Text>
       </Main>
     )
   }
 
   return (
-    <Main className="min-h-dvh bg-emerald-950 text-emerald-100">
+    <Main
+      lang="ca"
+      className="min-h-dvh bg-emerald-950 pb-[max(1.5rem,env(safe-area-inset-bottom))] text-emerald-100"
+    >
       <Box className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6 sm:px-6 md:gap-8 md:py-10">
         <Header className="text-center">
           <Text className="text-lg font-semibold tracking-tight text-emerald-50 sm:text-xl">
-            Forbidden Words
+            Paraules prohibides
           </Text>
         </Header>
         <Section
@@ -113,7 +122,7 @@ export const GameShellView = ({
                 <Box className="flex justify-center">
                   <Button
                     type="button"
-                    className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+                    className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
                     onClick={onStartGame}
                   >
                     Començar partida

--- a/app/game/GameShell/__tests__/GameShell.test.tsx
+++ b/app/game/GameShell/__tests__/GameShell.test.tsx
@@ -120,6 +120,8 @@ describe('GameShellView', () => {
     const gameRegion = screen.getByRole('region', { name: /àrea de joc/i })
     expect(gameRegion).toBeInTheDocument()
 
+    expect(screen.getByText(/paraules prohibides/i)).toBeInTheDocument()
+
     expect(
       screen.getByRole('progressbar', { name: /paraules encertades/i }),
     ).toHaveAccessibleName(/paraules encertades/i)

--- a/app/ui/molecules/GameEndPanel/GameEndPanel.tsx
+++ b/app/ui/molecules/GameEndPanel/GameEndPanel.tsx
@@ -26,6 +26,11 @@ export const GameEndPanel = ({
 }: GameEndPanelProps) => {
   const [farewellVisible, setFarewellVisible] = useState(false)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const playAgainRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    playAgainRef.current?.focus()
+  }, [])
 
   const clearCloseTimer = () => {
     if (closeTimerRef.current !== null) {
@@ -67,8 +72,9 @@ export const GameEndPanel = ({
       </Text>
       <Box className="flex flex-col gap-3 sm:flex-row sm:justify-center">
         <Button
+          ref={playAgainRef}
           type="button"
-          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
           onClick={handlePlayAgain}
         >
           Tornar a jugar

--- a/app/ui/molecules/GameEndPanel/__tests__/GameEndPanel.test.tsx
+++ b/app/ui/molecules/GameEndPanel/__tests__/GameEndPanel.test.tsx
@@ -27,6 +27,20 @@ describe('GameEndPanel', () => {
     ).toBeInTheDocument()
   })
 
+  it('focuses Tornar a jugar when the panel mounts', () => {
+    render(
+      <GameEndPanel
+        result={GAME_RESULT.WON}
+        onPlayAgain={vi.fn()}
+        closeWindow={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: /tornar a jugar/i }),
+    ).toHaveFocus()
+  })
+
   it('shows a lost heading when result is lost', () => {
     render(
       <GameEndPanel

--- a/app/ui/molecules/GameWordCard/GameWordCard.tsx
+++ b/app/ui/molecules/GameWordCard/GameWordCard.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useRef } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 
 import { useSpeakTargetWord } from '@app/speech/useSpeakTargetWord'
 import { Box } from '@app/ui/atoms/Box/Box'
@@ -16,6 +21,12 @@ export type GameWordCardProps = {
   readonly onSelectOption: (option: string) => void
 }
 
+const OPTION_KEYS_NEXT = new Set([
+  'ArrowRight',
+  'ArrowDown',
+])
+const OPTION_KEYS_PREV = new Set(['ArrowLeft', 'ArrowUp'])
+
 export const GameWordCard = ({
   card,
   lastAnswerEffect,
@@ -23,10 +34,33 @@ export const GameWordCard = ({
 }: GameWordCardProps) => {
   const speak = useSpeakTargetWord()
   const listenRef = useRef<HTMLButtonElement>(null)
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
 
   useEffect(() => {
     listenRef.current?.focus()
   }, [card.word.correctOption])
+
+  const moveOptionFocus = useCallback((fromIndex: number, delta: number) => {
+    const n = card.shuffledOptions.length
+    if (n === 0) return
+    const nextIndex = (fromIndex + delta + n) % n
+    optionRefs.current[nextIndex]?.focus()
+  }, [card.shuffledOptions.length])
+
+  const handleOptionKeyDown = useCallback(
+    (optionIndex: number) => (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (OPTION_KEYS_NEXT.has(event.key)) {
+        event.preventDefault()
+        moveOptionFocus(optionIndex, 1)
+        return
+      }
+      if (OPTION_KEYS_PREV.has(event.key)) {
+        event.preventDefault()
+        moveOptionFocus(optionIndex, -1)
+      }
+    },
+    [moveOptionFocus],
+  )
 
   const incorrectTargetWord =
     lastAnswerEffect?.kind === ANSWER_EFFECT.INCORRECT
@@ -42,7 +76,7 @@ export const GameWordCard = ({
         <Button
           ref={listenRef}
           type="button"
-          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
           onClick={() => {
             speak(card.word.audioText)
           }}
@@ -64,11 +98,15 @@ export const GameWordCard = ({
         aria-label="Opcions d&apos;ortografia"
         className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-center"
       >
-        {card.shuffledOptions.map((option) => (
+        {card.shuffledOptions.map((option, optionIndex) => (
           <Button
             key={`${card.word.correctOption}-${option}`}
+            ref={(element) => {
+              optionRefs.current[optionIndex] = element
+            }}
             type="button"
             className="min-h-[44px] flex-1 rounded-md border border-emerald-700/80 bg-emerald-900/50 px-3 py-2 text-sm font-medium text-emerald-50 hover:bg-emerald-800/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 sm:min-w-[8rem]"
+            onKeyDown={handleOptionKeyDown(optionIndex)}
             onClick={() => {
               onSelectOption(option)
             }}

--- a/app/ui/molecules/GameWordCard/__tests__/GameWordCard.test.tsx
+++ b/app/ui/molecules/GameWordCard/__tests__/GameWordCard.test.tsx
@@ -144,6 +144,58 @@ describe('GameWordCard', () => {
     expect(onSelectOption).toHaveBeenCalledWith('perque')
   })
 
+  it('moves focus between options with arrow keys only within the option group', () => {
+    const onSelectOption = vi.fn()
+
+    render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    const optionLabels = baseCard.shuffledOptions
+    const first = screen.getByRole('button', { name: new RegExp(`^${optionLabels[0]}$`) })
+    const second = screen.getByRole('button', { name: new RegExp(`^${optionLabels[1]}$`) })
+    const third = screen.getByRole('button', { name: new RegExp(`^${optionLabels[2]}$`) })
+
+    first.focus()
+    expect(first).toHaveFocus()
+
+    fireEvent.keyDown(first, { key: 'ArrowRight' })
+    expect(second).toHaveFocus()
+
+    fireEvent.keyDown(second, { key: 'ArrowLeft' })
+    expect(first).toHaveFocus()
+
+    fireEvent.keyDown(first, { key: 'ArrowUp' })
+    expect(third).toHaveFocus()
+
+    fireEvent.keyDown(third, { key: 'ArrowDown' })
+    expect(first).toHaveFocus()
+  })
+
+  it('does not move focus from the listen control with arrow keys', async () => {
+    const onSelectOption = vi.fn()
+
+    render(
+      <GameWordCard
+        card={baseCard}
+        lastAnswerEffect={null}
+        onSelectOption={onSelectOption}
+      />,
+    )
+
+    const listen = screen.getByRole('button', { name: /escolta la paraula/i })
+    await waitFor(() => {
+      expect(listen).toHaveFocus()
+    })
+
+    fireEvent.keyDown(listen, { key: 'ArrowDown' })
+    expect(listen).toHaveFocus()
+  })
+
   it('shows Catalan error copy with the target word after an incorrect answer', () => {
     const onSelectOption = vi.fn()
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Forbidden Words</title>
+    <meta
+      name="description"
+      content="Joc web en català per practicar l'ortografia: escolta cada paraula amb veu sintètica (ca-ES) i tria l'opció correcta entre tres."
+    />
+    <title>Paraules prohibides</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Resum

Aquesta PR millora els resultats de **Lighthouse** (accessibilitat i SEO) i incorpora millores d'**a11y i còpia en català** alineades amb el product spec.

## Lighthouse / WCAG

- **Contrast (WCAG AA):** els botons primaris amb text blanc (`Començar partida`, `Escolta la paraula`, `Tornar a jugar`) passen de `bg-emerald-600` a **`bg-emerald-700`** amb hover una mica més clar (`hover:bg-emerald-600`), per superar el **4,5:1** en text normal (audit axe `color-contrast`).
- **SEO:** s'afegeix **`<meta name="description">`** en català a `index.html` i un **`public/robots.txt`** vàlid (`User-agent: *` / `Allow: /`) per al desplegament Vite/Netlify.

## Altres millores (mateixa branca)

- **Català:** títol de pàgina i capçalera «Paraules prohibides»; `lang="ca"` als `main`; padding **safe-area** per dispositius amb notch.
- **A11y:** tecles de fletxa entre les tres opcions de resposta; focus inicial a **Tornar a jugar** al final de partida; proves RTL associades.
- **`.gitignore`:** ignora la carpeta local **`.netlify`**.

## Verificació

- `npm test`, `npm run lint`, `npm run typecheck` passen en local.
- Recomanat després del merge: tornar a executar **`lighthouse_audit`** (MCP Chrome DevTools) sobre `http://localhost:5173/` per confirmar puntuacions.

## Context

Motivació dels canvis de contrast i SEO: informe MCP **Lighthouse** anterior (accessibilitat ~95 per contrast del botó verd; SEO per meta i `robots.txt`).
