### PR TITLE
feat(ui): tema clar amb tokens i palette suau (nens)

### DIFF
--- a/app/game/GameShell/GameShell.tsx
+++ b/app/game/GameShell/GameShell.tsx
@@ -45,17 +45,20 @@ export const GameShellView = ({
       />
     ) : null
 
+  const mainShellClass =
+    'flex min-h-dvh flex-col items-center justify-center bg-page px-4 py-8 text-foreground'
+
   if (speech.status === 'blocked') {
     return (
       <Main
         lang="ca"
-        className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 pb-[max(2rem,env(safe-area-inset-bottom))] text-emerald-50"
+        className={`${mainShellClass} pb-[max(2rem,env(safe-area-inset-bottom))]`}
       >
         <Section
           role="alert"
           aria-live="polite"
           lang="ca"
-          className="max-w-prose rounded-lg border border-red-900/60 bg-red-950/40 px-4 py-3 text-center"
+          className="max-w-prose rounded-lg border border-danger-border bg-danger-bg px-4 py-3 text-center text-danger-foreground"
         >
           <Text>{speech.message}</Text>
         </Section>
@@ -67,9 +70,11 @@ export const GameShellView = ({
     return (
       <Main
         lang="ca"
-        className="flex min-h-dvh items-center justify-center bg-emerald-950 px-4 py-8 pb-[max(2rem,env(safe-area-inset-bottom))] text-emerald-100"
+        className={`${mainShellClass} pb-[max(2rem,env(safe-area-inset-bottom))]`}
       >
-        <Text className="text-base">S'està comprovant la veu…</Text>
+        <Text className="text-base text-foreground-muted">
+          S'està comprovant la veu…
+        </Text>
       </Main>
     )
   }
@@ -77,32 +82,32 @@ export const GameShellView = ({
   return (
     <Main
       lang="ca"
-      className="min-h-dvh bg-emerald-950 pb-[max(1.5rem,env(safe-area-inset-bottom))] text-emerald-100"
+      className={`${mainShellClass} pb-[max(1.5rem,env(safe-area-inset-bottom))]`}
     >
       <Box className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6 sm:px-6 md:gap-8 md:py-10">
         <Header className="text-center">
-          <Text className="text-lg font-semibold tracking-tight text-emerald-50 sm:text-xl">
+          <Text className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">
             Paraules prohibides
           </Text>
         </Header>
         <Section
           aria-label="Àrea de joc"
-          className="flex flex-col gap-6 rounded-xl border border-emerald-800/50 bg-emerald-900/30 p-4 shadow-inner sm:p-6 md:gap-8"
+          className="flex flex-col gap-6 rounded-2xl border border-border-subtle bg-surface p-4 shadow-md ring-1 ring-border-subtle/50 sm:p-6 md:gap-8"
         >
           <GameProgressBars metrics={displayMetrics} />
           <Section
             aria-label="Targeta de joc"
-            className="flex min-h-[12rem] flex-col justify-center gap-4 rounded-lg border border-dashed border-emerald-700/60 bg-emerald-950/40 p-4 sm:min-h-[14rem]"
+            className="flex min-h-[12rem] flex-col justify-center gap-4 rounded-lg border border-dashed border-border-strong bg-surface-muted p-4 sm:min-h-[14rem]"
           >
             <RenderOrNull shouldRender={!hasActiveGame}>
-              <Text className="text-center text-sm text-emerald-200/90">
+              <Text className="text-center text-sm text-foreground-muted">
                 Esperant inici de partida.
               </Text>
               <RenderOrNull shouldRender={Boolean(onStartGame)}>
                 <Box className="flex justify-center">
                   <Button
                     type="button"
-                    className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+                    className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow hover:bg-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus"
                     onClick={onStartGame}
                   >
                     Començar partida

--- a/app/index.css
+++ b/app/index.css
@@ -1,1 +1,54 @@
 @import 'tailwindcss';
+
+@theme {
+  /* Page canvas — mid warm gray (less glare / eye fatigue than light stone-100) */
+  --color-page: #d4d0cb;
+
+  /* Surfaces — soft off-white, not pure white */
+  --color-surface: #f3f1ed;
+  --color-surface-muted: #e8e5e0;
+
+  /* Text */
+  --color-foreground: #292524;
+  --color-foreground-muted: #57534e;
+
+  /* Borders */
+  --color-border-subtle: #c9c4be;
+  --color-border-strong: #b8b2aa;
+
+  /* Accent — muted teal (lower chroma than default teal-600) */
+  --color-accent: #0f766e;
+  --color-accent-hover: #115e59;
+  --color-ring-focus: #0d9488;
+
+  /* Secondary / option chips — blend with card */
+  --color-chip-bg: #e8e5e0;
+  --color-chip-border: #b8b2aa;
+  --color-chip-hover: #dce8e6;
+
+  /* Progress bar track on card */
+  --color-progress-track: #c9c4be;
+
+  /* Card feedback (forbidden word / error highlight) — softer amber */
+  --color-warning-bg: #f0e4d4;
+  --color-warning-border: #d9b47a;
+  --color-warning-foreground: #713f12;
+
+  /* Voice / mic blocked */
+  --color-danger-bg: #f1e5e5;
+  --color-danger-border: #e7bcbc;
+  --color-danger-foreground: #7f1d1d;
+}
+
+@layer base {
+  html {
+    font-size: clamp(1.0625rem, 0.5vw + 0.95rem, 1.375rem);
+    line-height: 1.55;
+  }
+
+  body {
+    margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}

--- a/app/ui/atoms/ProgressMetricBar/ProgressMetricBar.tsx
+++ b/app/ui/atoms/ProgressMetricBar/ProgressMetricBar.tsx
@@ -13,10 +13,10 @@ export type ProgressMetricBarProps = {
 }
 
 function fillClassForErrors(severity: ErrorSeverity): string {
-  if (severity === ERROR_SEVERITY.GREEN) return 'bg-emerald-500'
-  if (severity === ERROR_SEVERITY.YELLOW) return 'bg-amber-400'
-  if (severity === ERROR_SEVERITY.ORANGE) return 'bg-orange-500'
-  return 'bg-red-600'
+  if (severity === ERROR_SEVERITY.GREEN) return 'bg-emerald-600'
+  if (severity === ERROR_SEVERITY.YELLOW) return 'bg-amber-500'
+  if (severity === ERROR_SEVERITY.ORANGE) return 'bg-orange-600'
+  return 'bg-red-700'
 }
 
 export const ProgressMetricBar = ({
@@ -30,14 +30,14 @@ export const ProgressMetricBar = ({
   const pct = Math.min(100, Math.round((current / safeTotal) * 100))
   const fillClass =
     variant === 'words'
-      ? 'bg-emerald-400'
+      ? 'bg-accent'
       : fillClassForErrors(errorSeverity ?? ERROR_SEVERITY.GREEN)
 
   return (
     <Box className="flex flex-col gap-2">
       <Box className="flex items-baseline justify-between gap-3">
-        <Text className="text-sm font-medium text-emerald-100/90">{ariaLabel}</Text>
-        <Text className="tabular-nums text-sm text-emerald-50">
+        <Text className="text-base font-medium text-foreground">{ariaLabel}</Text>
+        <Text className="tabular-nums text-base text-foreground-muted">
           {current} / {total}
         </Text>
       </Box>
@@ -47,7 +47,7 @@ export const ProgressMetricBar = ({
         aria-valuemin={0}
         aria-valuemax={total}
         aria-label={ariaLabel}
-        className="h-2.5 w-full overflow-hidden rounded-full bg-emerald-950/80"
+        className="h-2.5 w-full overflow-hidden rounded-full bg-progress-track"
       >
         <Box
           className={`h-full rounded-full transition-[width] duration-300 ${fillClass}`}

--- a/app/ui/molecules/GameEndPanel/GameEndPanel.tsx
+++ b/app/ui/molecules/GameEndPanel/GameEndPanel.tsx
@@ -35,7 +35,7 @@ export const GameEndPanel = ({
       <Text
         role="heading"
         aria-level={2}
-        className="text-lg font-semibold text-emerald-50"
+        className="text-lg font-semibold text-foreground"
       >
         {headingText}
       </Text>
@@ -43,14 +43,14 @@ export const GameEndPanel = ({
         <Button
           ref={playAgainRef}
           type="button"
-          className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          className="rounded-md bg-accent px-4 py-2 text-base font-medium text-white shadow hover:bg-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus"
           onClick={handlePlayAgain}
         >
           Tornar a jugar
         </Button>
         <Button
           type="button"
-          className="rounded-md border border-emerald-700/80 bg-emerald-900/50 px-4 py-2 text-sm font-medium text-emerald-50 hover:bg-emerald-800/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          className="rounded-md border border-chip-border bg-chip-bg px-4 py-2 text-base font-medium text-foreground hover:bg-chip-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus"
           onClick={handleExit}
         >
           Sortir del joc
@@ -60,7 +60,7 @@ export const GameEndPanel = ({
         <Text
           role="status"
           aria-live="polite"
-          className="text-base text-emerald-200/95"
+          className="text-base text-foreground-muted"
         >
           Fins una altra
         </Text>

--- a/app/ui/molecules/GameWordCard/GameWordCard.tsx
+++ b/app/ui/molecules/GameWordCard/GameWordCard.tsx
@@ -35,7 +35,7 @@ export const GameWordCard = ({
         <Button
           ref={listenRef}
           type="button"
-          className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white shadow hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          className="rounded-md bg-accent px-4 py-2 text-base font-medium text-white shadow hover:bg-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus"
           onClick={() => {
             speak(card.word.audioText)
           }}
@@ -47,7 +47,7 @@ export const GameWordCard = ({
         <Text
           role="status"
           aria-live="polite"
-          className="rounded-md border border-amber-800/60 bg-amber-950/50 px-3 py-2 text-center text-sm text-amber-100"
+          className="rounded-md border border-warning-border bg-warning-bg px-3 py-2 text-center text-base text-warning-foreground"
         >
           L&apos;opció correcta és {incorrectTargetWord}
         </Text>
@@ -64,7 +64,7 @@ export const GameWordCard = ({
               registerOptionRef(optionIndex, element)
             }}
             type="button"
-            className="min-h-[44px] flex-1 rounded-md border border-emerald-700/80 bg-emerald-900/50 px-3 py-2 text-sm font-medium text-emerald-50 hover:bg-emerald-800/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 sm:min-w-[8rem]"
+            className="min-h-[44px] flex-1 rounded-md border border-chip-border bg-chip-bg px-3 py-2 text-base font-medium text-foreground hover:bg-chip-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus sm:min-w-[8rem]"
             onKeyDown={handleOptionKeyDown(optionIndex)}
             onClick={() => {
               onSelectOption(option)


### PR DESCRIPTION
## Resum
Aquest PR incorpora el tema visual orientat a nens: tokens semàntics a `@theme`, layout centrat al shell del joc i components alineats (targeta de paraula, fi de partida, barres de progrés).

## Detalls
- **`app/index.css`**: colors de pàgina, superfície, text, vores, accent, chips, avisos i pista de barres; tipografia fluida base.
- **`GameShell.tsx`**: fons i contenidor centrat; targeta amb ombra més suau.
- **`ProgressMetricBar`**, **`GameWordCard`**, **`GameEndPanel`**: classes amb els nous tokens (contrast llegible sense blanc pur ni saturació excessiva).

## Verificació
- `npm run lint` i `npm run test` passen.

Made with [Cursor](https://cursor.com)