### PR TITLE
chore(agents): add remote-issue-from-findings skill and OpenCode wiring

### DIFF
--- a/.cursor/skills/remote-issue-from-findings/SKILL.md
+++ b/.cursor/skills/remote-issue-from-findings/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: remote-issue-from-findings
+description: >
+  Opens GitHub issues on the remote repository from requirements gaps, suggestions,
+  and code defects, applying labels that reflect each item's nature (type and optional area).
+  Use when the user asks to file issues, create GitHub issues from review findings, or
+  track follow-up work on origin.
+license: Apache-2.0
+metadata:
+  author: tictools
+  version: "1.0"
+---
+
+# Remote issues from findings
+
+## When to use
+
+- Turn **requirements gaps**, **suggestions**, or **errors** in code/logs into **tracked issues**.
+- Default tracker: **GitHub** for this repo (see `.github/workflows/`). Prefer **`gh`** when available.
+
+## Preconditions
+
+1. **Auth**: `gh auth status` succeeds for the target host, or the user provides another supported path and credentials.
+2. **Target repo**: Confirm `origin` (or the user-named remote) points to the intended GitHub repository before creating issues.
+3. **Labels**: GitHub labels must **already exist** on the repository, or the user must explicitly ask to create missing labels first. Do not assume `gh issue create --label` succeeds for unknown labels.
+
+## Labels by nature (required)
+
+Every issue MUST carry a **`type/*`** label chosen from the table below. Pick **exactly one** primary `type/*` per issue; split mixed work into separate issues.
+
+| Nature of finding | `type/*` label | Typical body focus |
+|-------------------|----------------|---------------------|
+| Incorrect behavior, regression, crash, failing test in prod path | `type/bug` | Repro steps, expected vs actual, scope |
+| Missing behavior vs agreed spec / product requirement | `type/feature` | User story, acceptance criteria, spec link |
+| Refactor, complexity, coupling, migration without user-visible bug | `type/debt` | Motivation, risk, suggested direction |
+| README, ADR, spec, or developer docs out of date / missing | `type/docs` | What to document, audience |
+| Tooling, CI, deps, formatting-at-scale, repo hygiene | `type/chore` | Commands, blast radius |
+| Non-blocking improvement (UX polish, perf idea without bug) | `type/enhancement` | Rationale, trade-offs |
+
+### Optional `area/*` (at most two)
+
+Infer from paths or conversation; omit if unclear.
+
+| Code / topic | Suggested `area/*` |
+|----------------|-------------------|
+| `app/`, UI, routes | `area/app` |
+| `core/` domain | `area/core` |
+| `tests/` harness, mothers, MSW | `area/tests` |
+| `.github/`, CI config | `area/ci` |
+| Cross-cutting / unknown | omit `area/*` |
+
+Do not invent ad-hoc labels outside `type/*` and `area/*` unless the user supplies an approved extension list.
+
+## Issue quality
+
+**Title**: imperative, scannable, roughly ≤ 72 characters, no vague placeholders (“fix stuff”).
+
+**Body** (GitHub-flavored Markdown):
+
+```markdown
+## Summary
+<one paragraph>
+
+## Context
+- Nature: <bug | feature gap | suggestion | …>
+- Hints: <paths, commands, SHAs if known>
+
+## Details
+- Observed: …
+- Impact: …
+
+## Acceptance criteria (or repro for bugs)
+- [ ] …
+```
+
+- **`type/bug`**: include **reproduction** (commands or steps) and **expected vs actual**.
+- **`type/feature`**: include **acceptance criteria** tied to specs when available (`.cursor/specs/`).
+
+## Workflow
+
+1. **Classify** each finding → one `type/*` (and optional `area/*`).
+2. **Dedupe**: search open issues (`gh issue list --search "keywords"`) before creating near-duplicates.
+3. **One unit of work per issue** unless items are strictly inseparable.
+4. **Create** (example):
+
+```bash
+gh issue create --title "…" --body-file /tmp/issue-body.md --label "type/bug,area/core"
+```
+
+5. **Reply** with the issue URL(s). Never paste secrets, tokens, or PII.
+
+## When not to create an issue
+
+- Nit-only style with no correctness, accessibility, security, or team-standard impact (comment in PR instead).
+- Already tracked: add a comment on the existing issue with new evidence.
+
+## See also
+
+- **`.cursor/skills/project-structure/SKILL.md`** — where `/app`, `/core`, and `/tests` live when inferring `area/*`.

--- a/.opencode/commands/domain.md
+++ b/.opencode/commands/domain.md
@@ -1,0 +1,11 @@
+---
+description: Domain (/core) change — structure, types, and TS conventions
+---
+
+Apply entity-first layout and TypeScript rules for `/core` work.
+
+@.cursor/skills/project-structure/SKILL.md
+
+@.cursor/skills/typescript/SKILL.md
+
+@.cursor/rules/typescript.mdc

--- a/.opencode/commands/new-component.md
+++ b/.opencode/commands/new-component.md
@@ -1,0 +1,13 @@
+---
+description: Create or refactor a React component using repo conventions
+---
+
+Component name or scope (from user): $ARGUMENTS
+
+Use the index and conventions below. Prefer path aliases `@app/*`, `@core/*`, `@tests/*`.
+
+@AGENTS.md
+
+@.cursor/skills/create-react-component/SKILL.md
+
+@.cursor/rules/create-react-component.mdc

--- a/.opencode/commands/remote-issue.md
+++ b/.opencode/commands/remote-issue.md
@@ -1,0 +1,7 @@
+---
+description: File GitHub issues from requirements, suggestions, or code findings with nature labels
+---
+
+Use the workflow below for the current task. Pass extra context as `$ARGUMENTS` if helpful (e.g. paths, error output).
+
+@.cursor/skills/remote-issue-from-findings/SKILL.md

--- a/.opencode/commands/tdd.md
+++ b/.opencode/commands/tdd.md
@@ -1,0 +1,9 @@
+---
+description: TDD workflow and where specs live in this repo
+---
+
+Follow Red → Green → Refactor for the current task. Use the project skills and layout below.
+
+@.cursor/skills/tdd/SKILL.md
+
+@.cursor/skills/project-structure/SKILL.md

--- a/.opencode/commands/ui-review.md
+++ b/.opencode/commands/ui-review.md
@@ -1,0 +1,9 @@
+---
+description: UI review — Atomic Design strict HTML-in-atoms
+---
+
+Review UI changes against Atomic Design rules. For visual-only conditional rendering (`&&`, ternary show/hide) in molecules/organisms, load the skill `atomic-design-ui` (RenderOrNull / RenderOrFallback) via the skill tool.
+
+@.cursor/rules/atomic-design-ui.mdc
+
+@.cursor/skills/atomic-design-ui/SKILL.md

--- a/.opencode/skills/atomic-design-ui/SKILL.md
+++ b/.opencode/skills/atomic-design-ui/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/atomic-design-ui/SKILL.md

--- a/.opencode/skills/create-react-component/SKILL.md
+++ b/.opencode/skills/create-react-component/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/create-react-component/SKILL.md

--- a/.opencode/skills/hooks-testing-and-mocks/SKILL.md
+++ b/.opencode/skills/hooks-testing-and-mocks/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/hooks-testing-and-mocks/SKILL.md

--- a/.opencode/skills/project-structure/SKILL.md
+++ b/.opencode/skills/project-structure/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/project-structure/SKILL.md

--- a/.opencode/skills/remote-issue-from-findings/SKILL.md
+++ b/.opencode/skills/remote-issue-from-findings/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/remote-issue-from-findings/SKILL.md

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/skill-creator/SKILL.md

--- a/.opencode/skills/tdd/SKILL.md
+++ b/.opencode/skills/tdd/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/tdd/SKILL.md

--- a/.opencode/skills/tests-mothers-and-mocks/SKILL.md
+++ b/.opencode/skills/tests-mothers-and-mocks/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/tests-mothers-and-mocks/SKILL.md

--- a/.opencode/skills/typescript/SKILL.md
+++ b/.opencode/skills/typescript/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/typescript/SKILL.md

--- a/.opencode/skills/vercel-react-best-practices/SKILL.md
+++ b/.opencode/skills/vercel-react-best-practices/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/vercel-react-best-practices/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Agent context (Cursor + OpenCode)
+
+This file is a human-readable index for **Cursor** and **OpenCode**. Canonical skill content lives under [`.cursor/skills/<name>/SKILL.md`](.cursor/skills); Cursor loads rules from [`.cursor/rules/*.mdc`](.cursor/rules).
+
+## Cursor
+
+- **Rules**: `.cursor/rules/*.mdc` (see each file’s `globs` / `alwaysApply`).
+- **Skills**: `.cursor/skills/<name>/SKILL.md` (discovered by Cursor).
+
+## OpenCode
+
+- **Skills**: OpenCode loads `skills/*/SKILL.md` under [`.opencode/skills/`](.opencode/skills). In this repo each `.opencode/skills/<name>/SKILL.md` is a **symlink** to the canonical [`.cursor/skills/<name>/SKILL.md`](.cursor/skills) so there is a single source of truth.
+- **Config**: [opencode.json](opencode.json) at the repo root (`permission.skill` defaults to allow project skills).
+- **Docs**: [Agent skills](https://open-code.ai/en/docs/skills) · [Custom commands](https://open-code.ai/en/docs/commands) · [Config](https://open-code.ai/en/docs/config).
+
+### Symlinks and Windows
+
+If symlinks show up as plain text files after clone, enable `git config core.symlinks true` and clone/checkout again on Windows, or recreate the symlinks using the same relative target: `../../../.cursor/skills/<name>/SKILL.md` from `.opencode/skills/<name>/SKILL.md`.
+
+### Custom commands (TUI `/…`)
+
+Defined in [`.opencode/commands/`](.opencode/commands):
+
+| Command | File | Purpose |
+|---------|------|---------|
+| `/tdd` | [tdd.md](.opencode/commands/tdd.md) | TDD workflow + project layout skills |
+| `/new-component` | [new-component.md](.opencode/commands/new-component.md) | New/refactor component; pass name as `$ARGUMENTS` |
+| `/domain` | [domain.md](.opencode/commands/domain.md) | `/core` structure + TypeScript skill + rule |
+| `/ui-review` | [ui-review.md](.opencode/commands/ui-review.md) | Atomic Design rule + visual-guard skill |
+| `/remote-issue` | [remote-issue.md](.opencode/commands/remote-issue.md) | GitHub issues from findings + `type/*` labels |
+
+## Skills (workflows & architecture)
+
+| Skill | Canonical path |
+|--------|----------------|
+| Atomic Design (visual guards) | [.cursor/skills/atomic-design-ui/SKILL.md](.cursor/skills/atomic-design-ui/SKILL.md) |
+| Create React component / hooks | [.cursor/skills/create-react-component/SKILL.md](.cursor/skills/create-react-component/SKILL.md) |
+| Hooks: testing & mocks | [.cursor/skills/hooks-testing-and-mocks/SKILL.md](.cursor/skills/hooks-testing-and-mocks/SKILL.md) |
+| Project structure (`/app`, `/core`, `/tests`) | [.cursor/skills/project-structure/SKILL.md](.cursor/skills/project-structure/SKILL.md) |
+| TDD | [.cursor/skills/tdd/SKILL.md](.cursor/skills/tdd/SKILL.md) |
+| Tests: mothers & mocks | [.cursor/skills/tests-mothers-and-mocks/SKILL.md](.cursor/skills/tests-mothers-and-mocks/SKILL.md) |
+| TypeScript (`/core` extensions) | [.cursor/skills/typescript/SKILL.md](.cursor/skills/typescript/SKILL.md) |
+| Vercel React best practices (summary) | [.cursor/skills/vercel-react-best-practices/SKILL.md](.cursor/skills/vercel-react-best-practices/SKILL.md) |
+| Skill authoring | [.cursor/skills/skill-creator/SKILL.md](.cursor/skills/skill-creator/SKILL.md) |
+| Remote GitHub issues (labeled by nature) | [.cursor/skills/remote-issue-from-findings/SKILL.md](.cursor/skills/remote-issue-from-findings/SKILL.md) |
+
+## Project rules (short, contextual)
+
+| Topic | Path |
+|--------|------|
+| TypeScript (base patterns) | [.cursor/rules/typescript.mdc](.cursor/rules/typescript.mdc) |
+| React component conventions | [.cursor/rules/create-react-component.mdc](.cursor/rules/create-react-component.mdc) |
+| Atomic Design (strict HTML in atoms) | [.cursor/rules/atomic-design-ui.mdc](.cursor/rules/atomic-design-ui.mdc) |
+| Vercel performance checklist | [.cursor/rules/vercel-react-best-practices.mdc](.cursor/rules/vercel-react-best-practices.mdc) |
+
+## Specs
+
+- Product: [.cursor/specs/product/SPECS_v1.md](.cursor/specs/product/SPECS_v1.md)
+- Tech: [.cursor/specs/tech/SPECS_v1.md](.cursor/specs/tech/SPECS_v1.md)

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "skill": {
+      "*": "allow"
+    }
+  }
+}


### PR DESCRIPTION
Add Cursor skill to file GitHub issues from findings with type/* (and optional area/*) labels. Register AGENTS.md index, opencode.json, slash commands, and symlinked skills under .opencode/skills/.

Made-with: Cursor
