### PR TITLE
feat(ui): semantic headings (Phase B)

### DIFF
--- a/app/game/GameShell/GameShell.tsx
+++ b/app/game/GameShell/GameShell.tsx
@@ -1,6 +1,7 @@
 import { useGameShell } from '@app/game/GameShell/useGameShell/useGameShell'
 import { Box } from '@app/ui/atoms/Box/Box'
 import { Header } from '@app/ui/atoms/Header/Header'
+import { Heading } from '@app/ui/atoms/Heading/Heading'
 import { Button } from '@app/ui/atoms/Button/Button'
 import { Main } from '@app/ui/atoms/Main/Main'
 import { RenderOrNull } from '@app/ui/atoms/RenderOrNull/RenderOrNull'
@@ -86,9 +87,12 @@ export const GameShellView = ({
     >
       <Box className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-6 sm:px-6 md:gap-8 md:py-10">
         <Header className="text-center">
-          <Text className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+          <Heading
+            level={1}
+            className="text-lg font-semibold tracking-tight text-foreground sm:text-xl"
+          >
             Paraules prohibides
-          </Text>
+          </Heading>
         </Header>
         <Section
           aria-label="Àrea de joc"

--- a/app/game/GameShell/__tests__/GameShell.test.tsx
+++ b/app/game/GameShell/__tests__/GameShell.test.tsx
@@ -120,7 +120,9 @@ describe('GameShellView', () => {
     const gameRegion = screen.getByRole('region', { name: /àrea de joc/i })
     expect(gameRegion).toBeInTheDocument()
 
-    expect(screen.getByText(/paraules prohibides/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 1, name: /paraules prohibides/i }),
+    ).toBeInTheDocument()
 
     expect(
       screen.getByRole('progressbar', { name: /paraules encertades/i }),
@@ -187,7 +189,7 @@ describe('GameShellView', () => {
       screen.getByRole('region', { name: /fi de partida/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('heading', { name: /has guanyat/i }),
+      screen.getByRole('heading', { level: 2, name: /has guanyat/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /tornar a jugar/i }),
@@ -214,7 +216,7 @@ describe('GameShellView', () => {
     )
 
     expect(
-      screen.getByRole('heading', { name: /has perdut/i }),
+      screen.getByRole('heading', { level: 2, name: /has perdut/i }),
     ).toBeInTheDocument()
   })
 
@@ -336,7 +338,7 @@ describe('GameShell', () => {
     }
 
     expect(
-      screen.getByRole('heading', { name: /has guanyat/i }),
+      screen.getByRole('heading', { level: 2, name: /has guanyat/i }),
     ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /tornar a jugar/i }))
@@ -371,7 +373,7 @@ describe('GameShell', () => {
     }
 
     expect(
-      screen.getByRole('heading', { name: /has perdut/i }),
+      screen.getByRole('heading', { level: 2, name: /has perdut/i }),
     ).toBeInTheDocument()
     expect(useGameStore.getState().game?.result).toBe(GAME_RESULT.LOST)
   })
@@ -400,7 +402,7 @@ describe('GameShell', () => {
     }
 
     expect(
-      screen.getByRole('heading', { name: /has guanyat/i }),
+      screen.getByRole('heading', { level: 2, name: /has guanyat/i }),
     ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /sortir del joc/i }))

--- a/app/ui/atoms/Heading/Heading.tsx
+++ b/app/ui/atoms/Heading/Heading.tsx
@@ -1,0 +1,22 @@
+import type { HTMLAttributes } from 'react'
+
+export type HeadingLevel = 1 | 2 | 3
+
+export type HeadingProps = {
+  readonly level: HeadingLevel
+} & HTMLAttributes<HTMLHeadingElement>
+
+export const Heading = ({ level, ...rest }: HeadingProps) => {
+  switch (level) {
+    case 1:
+      return <h1 {...rest} />
+    case 2:
+      return <h2 {...rest} />
+    case 3:
+      return <h3 {...rest} />
+    default: {
+      const _exhaustive: never = level
+      return _exhaustive
+    }
+  }
+}

--- a/app/ui/atoms/Heading/__tests__/Heading.test.tsx
+++ b/app/ui/atoms/Heading/__tests__/Heading.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Heading } from '@app/ui/atoms/Heading/Heading'
+
+describe('Heading', () => {
+  it('renders h1 when level is 1', () => {
+    render(<Heading level={1}>Title</Heading>)
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Title' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders h2 when level is 2', () => {
+    render(<Heading level={2}>Subtitle</Heading>)
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Subtitle' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders h3 when level is 3', () => {
+    render(<Heading level={3}>Section</Heading>)
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Section' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/app/ui/molecules/GameEndPanel/GameEndPanel.tsx
+++ b/app/ui/molecules/GameEndPanel/GameEndPanel.tsx
@@ -2,6 +2,7 @@ import { Box } from '@app/ui/atoms/Box/Box'
 import { Button } from '@app/ui/atoms/Button/Button'
 import { RenderOrNull } from '@app/ui/atoms/RenderOrNull/RenderOrNull'
 import { Section } from '@app/ui/atoms/Section/Section'
+import { Heading } from '@app/ui/atoms/Heading/Heading'
 import { Text } from '@app/ui/atoms/Text/Text'
 import { useGameEndPanel } from '@app/ui/molecules/GameEndPanel/useGameEndPanel/useGameEndPanel'
 import type { GameResult } from '@core/Game/Game'
@@ -32,13 +33,9 @@ export const GameEndPanel = ({
       aria-label="Fi de partida"
       className="flex flex-col items-center gap-4 text-center"
     >
-      <Text
-        role="heading"
-        aria-level={2}
-        className="text-lg font-semibold text-foreground"
-      >
+      <Heading level={2} className="text-lg font-semibold text-foreground">
         {headingText}
-      </Text>
+      </Heading>
       <Box className="flex flex-col gap-3 sm:flex-row sm:justify-center">
         <Button
           ref={playAgainRef}

--- a/app/ui/molecules/GameEndPanel/__tests__/GameEndPanel.test.tsx
+++ b/app/ui/molecules/GameEndPanel/__tests__/GameEndPanel.test.tsx
@@ -15,7 +15,7 @@ describe('GameEndPanel', () => {
     )
 
     expect(
-      screen.getByRole('heading', { name: /has guanyat/i }),
+      screen.getByRole('heading', { level: 2, name: /has guanyat/i }),
     ).toBeInTheDocument()
   })
 
@@ -29,7 +29,7 @@ describe('GameEndPanel', () => {
     )
 
     expect(
-      screen.getByRole('heading', { name: /has perdut/i }),
+      screen.getByRole('heading', { level: 2, name: /has perdut/i }),
     ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Phase B of UI modernization: real document headings for the game shell title and end-of-game message.

## Changes

- Add `Heading` atom (`level` 1–3) mapping to native `h1`–`h3`.
- `GameShell`: app title uses `h1` via `Heading`.
- `GameEndPanel`: end title uses `h2` (replaces `Text` with `role="heading"` / `aria-level`).
- RTL: assert heading levels; new `Heading` tests.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test`

## Notes

- Branch base is `main`; if Phase A is not merged yet, rebase or retarget the PR as needed.

Made with [Cursor](https://cursor.com)